### PR TITLE
Fix compatibility with webpack-bundle-analyzer

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,4 +11,6 @@ const acornStage3 = require('acorn-stage3');
 // @ts-ignore
 acorn.Parser = acornStage3(acorn.Parser);
 
+acorn.parse = (...args) => acorn.Parser.parse(...args);
+
 module.exports = acorn;


### PR DESCRIPTION
`webpack-bundle-analyzer` uses `acorn.parse()` instead of the `acorn.Parser` instance. This PR adds an overload for this function so `webpack-bundle-analyzer` displays stats for code with the latest ECMA features.